### PR TITLE
Autoplay on iOS

### DIFF
--- a/src/VideoBackground.vue
+++ b/src/VideoBackground.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="VideoBg">
-    <video autoplay loop muted ref="video">
+    <video autoplay playsinline loop muted ref="video">
       <source v-for="source in sources" :src="source" :type="getMediaType(source)">
     </video>
     <div class="VideoBg__content">


### PR DESCRIPTION
The `playsinline` tag is needed for mobile Safari on iOS 10+ for the video to play without a click/touch event.